### PR TITLE
Added Dockerfile to enable use of legacy packages etc. 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+^Dockerfile$

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y && \
     texinfo \
     libqpdf-dev \
     libmagick++-dev \
+    libicu \
     && apt-get clean
 
 ## Get JAVA

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,14 @@ RUN apt-get update -y && \
     libqpdf-dev \
     libmagick++-dev \
     && apt-get clean
-    
+
+## Get JAVA
+RUN apt-get update -qq \
+  && apt-get -y --no-install-recommends install \
+    default-jdk \
+    default-jre \
+  && R CMD javareconf
+  
 ADD . /home/rstudio/rEHR
 
 RUN Rscript -e 'devtools::install_dev_deps("home/rstudio/rEHR")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     texinfo \
     libqpdf-dev \
     libmagick++-dev \
-    libicu \
+    libicu-dev \
     && apt-get clean
 
 ## Get JAVA

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+From rocker/tidyverse:3.3.2
+
+RUN apt-get update -y && \
+    apt-get install -y \
+    texlive-latex-recommended \
+    texlive-fonts-extra \
+    texinfo \
+    libqpdf-dev \
+    libmagick++-dev \
+    && apt-get clean
+    
+ADD . /home/rstudio/rEHR
+
+RUN Rscript -e 'devtools::install_dev_deps("home/rstudio/rEHR")'
+
+RUN Rscript -e 'devtools::install("home/rstudio/rEHR")'


### PR DESCRIPTION
Hi, 

I just wrote a quick Dockerfile to enable a colleague to assess this package for their workflow and thought adding to the package it might be helpful. 

 Based on the `rocker/tidyverse`  container so all running instructions that are relevant there are required here.

Basic run command is:

```
docker build . -t rehr
docker run -d -p 8787:8787 -e USER=rehr -e PASSWORD=rehr --name rehr rehr
```

Thanks, 

Sam